### PR TITLE
Ipython profile creates a profile it doesn't exist.

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,3 +1,2 @@
 jupyter labextension install jupyterlab-toc
-ipython profile create default
 importnb-install

--- a/src/importnb/notebooks/utils/ipython.ipynb
+++ b/src/importnb/notebooks/utils/ipython.ipynb
@@ -2,30 +2,15 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
     "    from IPython import paths, get_ipython\n",
-    "    from IPython.core.profiledir import ProfileDir, ProfileDirError\n",
+    "    from IPython.core import profiledir\n",
     "    from pathlib import Path\n",
     "    import json, ast\n",
     "    import os"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "    def load_create_profile(profile='default'):\n",
-    "        try:\n",
-    "            dir = paths.locate_profile(profile)\n",
-    "        except OSError:\n",
-    "            get_ipython().profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)\n",
-    "        return paths.locate_profile(profile)\n",
-    "            "
    ]
   },
   {
@@ -35,14 +20,12 @@
    "outputs": [],
    "source": [
     "    def get_config(profile='default'):\n",
-    "        ip = get_ipython()\n",
-    "        load_create_profile()\n",
-    "        path = os.pathsep.join((\n",
-    "            ip.profile_dir.location if ip else paths.locate_profile(profile),  \"ipython_config.json\"\n",
-    "        ))\n",
-    "        if not os.path.exists(path):\n",
-    "            with open(path, 'w') as f: f.write('{}')\n",
-    "        return Path(path)"
+    "        profile_dir = profiledir.ProfileDir()\n",
+    "        try:\n",
+    "            profile = profile_dir.find_profile_dir_by_name(paths.get_ipython_dir(), profile)\n",
+    "        except profiledir.ProfileDirError:\n",
+    "            profile = profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)\n",
+    "        return Path(profile.location)"
    ]
   },
   {

--- a/src/importnb/notebooks/utils/ipython.ipynb
+++ b/src/importnb/notebooks/utils/ipython.ipynb
@@ -38,11 +38,11 @@
     "        ip = get_ipython()\n",
     "        load_create_profile()\n",
     "        path = os.pathsep.join((\n",
-    "            ip.profile_dir.location if ip else paths.locate_profile(profile),  \"ipython_config.json\"\n",
+    "            get_ipython().profile_dir.location if ip else paths.locate_profile(profile),  \"ipython_config.json\"\n",
     "        ))\n",
     "        if not os.path.exists(path):\n",
     "            with open(path, 'w') as f: f.write('{}')\n",
-    "        return path"
+    "        return Path(path)"
    ]
   },
   {

--- a/src/importnb/notebooks/utils/ipython.ipynb
+++ b/src/importnb/notebooks/utils/ipython.ipynb
@@ -24,6 +24,7 @@
     "        try:\n",
     "            profile = profile_dir.find_profile_dir_by_name(paths.get_ipython_dir(), profile)\n",
     "        except profiledir.ProfileDirError:\n",
+    "            os.makedirs(paths.get_ipython_dir(), exist_ok=True)\n",
     "            profile = profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)\n",
     "        return Path(profile.location, 'ipython_config.json')"
    ]

--- a/src/importnb/notebooks/utils/ipython.ipynb
+++ b/src/importnb/notebooks/utils/ipython.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,12 +25,12 @@
     "            profile = profile_dir.find_profile_dir_by_name(paths.get_ipython_dir(), profile)\n",
     "        except profiledir.ProfileDirError:\n",
     "            profile = profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)\n",
-    "        return Path(profile.location)"
+    "        return Path(profile.location, 'ipython_config.json')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "scrolled": false
    },

--- a/src/importnb/notebooks/utils/ipython.ipynb
+++ b/src/importnb/notebooks/utils/ipython.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,22 +29,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
     "    def get_config(profile='default'):\n",
     "        ip = get_ipython()\n",
     "        load_create_profile()\n",
-    "        config = Path(ip.profile_dir.location if ip else paths.locate_profile(profile)) /  \"ipython_config.json\"\n",
-    "        if not config.exists():\n",
-    "            config.write_text('{}')\n",
+    "        path = os.pathsep.join((\n",
+    "            ip.profile_dir.location if ip else paths.locate_profile(profile),  \"ipython_config.json\"\n",
+    "        ))\n",
+    "        if not os.path.exists(path):\n",
+    "            with open(path, 'w') as f: f.write('{}')\n",
     "        return config"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "metadata": {
     "scrolled": false
    },
@@ -124,6 +135,13 @@
     "        from importnb.utils.export import export\n",
     "        export('ipython.ipynb', '../../utils/ipython.py')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/src/importnb/notebooks/utils/ipython.ipynb
+++ b/src/importnb/notebooks/utils/ipython.ipynb
@@ -9,7 +9,8 @@
     "    from IPython import paths, get_ipython\n",
     "    from IPython.core.profiledir import ProfileDir, ProfileDirError\n",
     "    from pathlib import Path\n",
-    "    import json, ast"
+    "    import json, ast\n",
+    "    import os"
    ]
   },
   {
@@ -29,16 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "    import os"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,12 +42,12 @@
     "        ))\n",
     "        if not os.path.exists(path):\n",
     "            with open(path, 'w') as f: f.write('{}')\n",
-    "        return config"
+    "        return path"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 9,
    "metadata": {
     "scrolled": false
    },

--- a/src/importnb/notebooks/utils/ipython.ipynb
+++ b/src/importnb/notebooks/utils/ipython.ipynb
@@ -6,7 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "    from IPython import paths, get_ipython"
+    "    from IPython import paths, get_ipython\n",
+    "    from IPython.core.profiledir import ProfileDir, ProfileDirError"
    ]
   },
   {
@@ -21,18 +22,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "    def get_config():\n",
-    "        ip = get_ipython()\n",
-    "        return Path(ip.profile_dir.location if ip else paths.locate_profile()) /  \"ipython_config.json\"  "
+    "    "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    def load_create_profile(profile='default'):\n",
+    "        try:\n",
+    "            dir = paths.locate_profile(profile)\n",
+    "        except ProfileDirError:\n",
+    "            ip.profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)\n",
+    "        return paths.locate_profile(profile)\n",
+    "            "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    def get_config(profile='default'):\n",
+    "        ip = get_ipython()\n",
+    "        load_create_profile()\n",
+    "        config = Path(ip.profile_dir.location if ip else paths.locate_profile(profile)) /  \"ipython_config.json\"\n",
+    "        if not config.exists():\n",
+    "            config.write_text('{}')\n",
+    "        return config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 9,
    "metadata": {
     "scrolled": false
    },
@@ -112,13 +141,6 @@
     "        from importnb.utils.export import export\n",
     "        export('ipython.ipynb', '../../utils/ipython.py')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -137,7 +159,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/src/importnb/notebooks/utils/ipython.ipynb
+++ b/src/importnb/notebooks/utils/ipython.ipynb
@@ -7,26 +7,9 @@
    "outputs": [],
    "source": [
     "    from IPython import paths, get_ipython\n",
-    "    from IPython.core.profiledir import ProfileDir, ProfileDirError"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "    from IPython.core.profiledir import ProfileDir, ProfileDirError\n",
     "    from pathlib import Path\n",
     "    import json, ast"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "    "
    ]
   },
   {
@@ -38,7 +21,7 @@
     "    def load_create_profile(profile='default'):\n",
     "        try:\n",
     "            dir = paths.locate_profile(profile)\n",
-    "        except ProfileDirError:\n",
+    "        except OSError:\n",
     "            ip.profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)\n",
     "        return paths.locate_profile(profile)\n",
     "            "

--- a/src/importnb/notebooks/utils/ipython.ipynb
+++ b/src/importnb/notebooks/utils/ipython.ipynb
@@ -23,14 +23,14 @@
     "        try:\n",
     "            dir = paths.locate_profile(profile)\n",
     "        except OSError:\n",
-    "            ip.profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)\n",
+    "            get_ipython().profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)\n",
     "        return paths.locate_profile(profile)\n",
     "            "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
     "        ip = get_ipython()\n",
     "        load_create_profile()\n",
     "        path = os.pathsep.join((\n",
-    "            get_ipython().profile_dir.location if ip else paths.locate_profile(profile),  \"ipython_config.json\"\n",
+    "            ip.profile_dir.location if ip else paths.locate_profile(profile),  \"ipython_config.json\"\n",
     "        ))\n",
     "        if not os.path.exists(path):\n",
     "            with open(path, 'w') as f: f.write('{}')\n",
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "scrolled": false
    },
@@ -127,13 +127,6 @@
     "        from importnb.utils.export import export\n",
     "        export('ipython.ipynb', '../../utils/ipython.py')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/src/importnb/utils/ipython.py
+++ b/src/importnb/utils/ipython.py
@@ -1,29 +1,18 @@
 # coding: utf-8
 from IPython import paths, get_ipython
-from IPython.core.profiledir import ProfileDir, ProfileDirError
+from IPython.core import profiledir
 from pathlib import Path
 import json, ast
 import os
 
 
-def load_create_profile(profile="default"):
-    try:
-        dir = paths.locate_profile(profile)
-    except OSError:
-        get_ipython().profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)
-    return paths.locate_profile(profile)
-
-
 def get_config(profile="default"):
-    ip = get_ipython()
-    load_create_profile()
-    path = os.pathsep.join(
-        (ip.profile_dir.location if ip else paths.locate_profile(profile), "ipython_config.json")
-    )
-    if not os.path.exists(path):
-        with open(path, "w") as f:
-            f.write("{}")
-    return Path(path)
+    profile_dir = profiledir.ProfileDir()
+    try:
+        profile = profile_dir.find_profile_dir_by_name(paths.get_ipython_dir(), profile)
+    except profiledir.ProfileDirError:
+        profile = profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)
+    return Path(profile.location)
 
 
 def load_config():

--- a/src/importnb/utils/ipython.py
+++ b/src/importnb/utils/ipython.py
@@ -10,7 +10,7 @@ def load_create_profile(profile="default"):
     try:
         dir = paths.locate_profile(profile)
     except OSError:
-        ip.profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)
+        get_ipython().profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)
     return paths.locate_profile(profile)
 
 
@@ -18,10 +18,7 @@ def get_config(profile="default"):
     ip = get_ipython()
     load_create_profile()
     path = os.pathsep.join(
-        (
-            get_ipython().profile_dir.location if ip else paths.locate_profile(profile),
-            "ipython_config.json",
-        )
+        (ip.profile_dir.location if ip else paths.locate_profile(profile), "ipython_config.json")
     )
     if not os.path.exists(path):
         with open(path, "w") as f:

--- a/src/importnb/utils/ipython.py
+++ b/src/importnb/utils/ipython.py
@@ -13,15 +13,18 @@ def load_create_profile(profile="default"):
     return paths.locate_profile(profile)
 
 
+import os
+
+
 def get_config(profile="default"):
     ip = get_ipython()
     load_create_profile()
-    config = (
-        Path(ip.profile_dir.location if ip else paths.locate_profile(profile))
-        / "ipython_config.json"
+    path = os.pathsep.join(
+        (ip.profile_dir.location if ip else paths.locate_profile(profile), "ipython_config.json")
     )
-    if not config.exists():
-        config.write_text("{}")
+    if not os.path.exists(path):
+        with open(path, "w") as f:
+            f.write("{}")
     return config
 
 

--- a/src/importnb/utils/ipython.py
+++ b/src/importnb/utils/ipython.py
@@ -1,13 +1,29 @@
 # coding: utf-8
 from IPython import paths, get_ipython
+from IPython.core.profiledir import ProfileDir, ProfileDirError
 
 from pathlib import Path
 import json, ast
 
 
-def get_config():
+def load_create_profile(profile="default"):
+    try:
+        dir = paths.locate_profile(profile)
+    except ProfileDirError:
+        ip.profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)
+    return paths.locate_profile(profile)
+
+
+def get_config(profile="default"):
     ip = get_ipython()
-    return Path(ip.profile_dir.location if ip else paths.locate_profile()) / "ipython_config.json"
+    load_create_profile()
+    config = (
+        Path(ip.profile_dir.location if ip else paths.locate_profile(profile))
+        / "ipython_config.json"
+    )
+    if not config.exists():
+        config.write_text("{}")
+    return config
 
 
 def load_config():

--- a/src/importnb/utils/ipython.py
+++ b/src/importnb/utils/ipython.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 from IPython import paths, get_ipython
 from IPython.core.profiledir import ProfileDir, ProfileDirError
-
 from pathlib import Path
 import json, ast
 
@@ -9,7 +8,7 @@ import json, ast
 def load_create_profile(profile="default"):
     try:
         dir = paths.locate_profile(profile)
-    except ProfileDirError:
+    except OSError:
         ip.profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)
     return paths.locate_profile(profile)
 

--- a/src/importnb/utils/ipython.py
+++ b/src/importnb/utils/ipython.py
@@ -11,6 +11,7 @@ def get_config(profile="default"):
     try:
         profile = profile_dir.find_profile_dir_by_name(paths.get_ipython_dir(), profile)
     except profiledir.ProfileDirError:
+        os.makedirs(paths.get_ipython_dir(), exist_ok=True)
         profile = profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)
     return Path(profile.location, "ipython_config.json")
 

--- a/src/importnb/utils/ipython.py
+++ b/src/importnb/utils/ipython.py
@@ -12,7 +12,7 @@ def get_config(profile="default"):
         profile = profile_dir.find_profile_dir_by_name(paths.get_ipython_dir(), profile)
     except profiledir.ProfileDirError:
         profile = profile_dir.create_profile_dir_by_name(paths.get_ipython_dir(), profile)
-    return Path(profile.location)
+    return Path(profile.location, "ipython_config.json")
 
 
 def load_config():

--- a/src/importnb/utils/ipython.py
+++ b/src/importnb/utils/ipython.py
@@ -25,7 +25,7 @@ def get_config(profile="default"):
     if not os.path.exists(path):
         with open(path, "w") as f:
             f.write("{}")
-    return config
+    return path
 
 
 def load_config():

--- a/src/importnb/utils/ipython.py
+++ b/src/importnb/utils/ipython.py
@@ -3,6 +3,7 @@ from IPython import paths, get_ipython
 from IPython.core.profiledir import ProfileDir, ProfileDirError
 from pathlib import Path
 import json, ast
+import os
 
 
 def load_create_profile(profile="default"):
@@ -13,19 +14,19 @@ def load_create_profile(profile="default"):
     return paths.locate_profile(profile)
 
 
-import os
-
-
 def get_config(profile="default"):
     ip = get_ipython()
     load_create_profile()
     path = os.pathsep.join(
-        (ip.profile_dir.location if ip else paths.locate_profile(profile), "ipython_config.json")
+        (
+            get_ipython().profile_dir.location if ip else paths.locate_profile(profile),
+            "ipython_config.json",
+        )
     )
     if not os.path.exists(path):
         with open(path, "w") as f:
             f.write("{}")
-    return path
+    return Path(path)
 
 
 def load_config():


### PR DESCRIPTION
Fix #72 by creating a default profile if it doesn't exist.  This is good because `importnb-install` can be added `postBuild` easier when creating a binder.