### PR TITLE
Pytest extensions to test restart and run all + docstrings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,10 @@ setup_args = dict(
     zip_safe=False,
     cmdclass={'test': PyTest,},
     entry_points = {
-        'pytest11': ['pytest-importnb = importnb.utils.pytest_plugin',],
+        'pytest11': [
+            'pytest-importnb = importnb.utils.pytest_importnb',
+            'nbsource = importnb.utils.pytest_nbsource',
+        ],
         'console_scripts': [
             'importnb-install = importnb.utils.ipython:install',
             'importnb-uninstall = importnb.utils.ipython:uninstall',

--- a/src/importnb/notebooks/utils/pytest_importnb.ipynb
+++ b/src/importnb/notebooks/utils/pytest_importnb.ipynb
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
     "                        for pat in parent.config.getini('python_files'):\n",
     "                            if path.fnmatch(pat.rstrip('.py') + path.ext): break\n",
     "                        else: return\n",
-    "                    if self.parent.config.option.doctestmodules:\n",
+    "                    if parent.config.option.doctestmodules:\n",
     "                        classes = list(module.__mro__)\n",
     "                        classes.insert(classes.index(_pytest.python.Module), _pytest.doctest.DoctestModule)\n",
     "                        module = type('DocTest'+module.__name__, tuple(classes), {})\n",
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 10,
    "metadata": {
     "scrolled": false
    },

--- a/src/importnb/notebooks/utils/pytest_importnb.ipynb
+++ b/src/importnb/notebooks/utils/pytest_importnb.ipynb
@@ -55,11 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "    class AlternativeModule(pytest.Module):\n",
-    "        def _getobj(self):\n",
-    "            return self.loader(\n",
-    "                self.parent.config.option.main and \"__main__\" or None\n",
-    "            ).load(str(self.fspath))"
+    "    import _pytest.doctest"
    ]
   },
   {
@@ -68,8 +64,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "    class NotebookModule(AlternativeModule): \n",
-    "        loader = Notebook"
+    "    class AlternativeModule(pytest.Module):\n",
+    "        def _getobj(self):\n",
+    "            return self.loader(\n",
+    "                self.parent.config.option.main and \"__main__\" or None\n",
+    "            ).load(str(self.fspath))\n",
+    "        \n",
+    "        def collect(self):\n",
+    "            yield from super().collect()\n",
+    "            if self.parent.config.option.doctestmodules:\n",
+    "                yield from _pytest.doctest.DoctestModule.collect(self)"
    ]
   },
   {
@@ -78,7 +82,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "    import _pytest.doctest"
+    "    class NotebookModule(AlternativeModule): \n",
+    "        loader = Notebook"
    ]
   },
   {
@@ -95,10 +100,6 @@
     "                        for pat in parent.config.getini('python_files'):\n",
     "                            if path.fnmatch(pat.rstrip('.py') + path.ext): break\n",
     "                        else: return\n",
-    "                    if parent.config.option.doctestmodules:\n",
-    "                        classes = list(module.__mro__)\n",
-    "                        classes.insert(classes.index(_pytest.python.Module), _pytest.doctest.DoctestModule)\n",
-    "                        module = type('DocTest'+module.__name__, tuple(classes), {})\n",
     "                    return module(path, parent)\n"
    ]
   },

--- a/src/importnb/notebooks/utils/pytest_importnb.ipynb
+++ b/src/importnb/notebooks/utils/pytest_importnb.ipynb
@@ -1,12 +1,23 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A `pytest` plugin for importing notebooks as modules and using standard test discovered.\n",
+    "\n",
+    "The `AlternativeModule` is reusable.  See `pidgin` for an example."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "    import importlib, pytest, abc, pathlib"
+    "    with __import__('importnb').Notebook():\n",
+    "        try: from . import testing\n",
+    "        except: from importnb.utils import testing"
    ]
   },
   {
@@ -15,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "    from importnb import Notebook"
+    "    import importlib, pytest, abc, pathlib"
    ]
   },
   {
@@ -24,10 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "    def pytest_addoption(parser):\n",
-    "        group = parser.getgroup(\"general\")\n",
-    "        group.addoption('--main', action='store_true',\n",
-    "                        help=\"Run in the main context.\")"
+    "    from importnb import Notebook"
    ]
   },
   {
@@ -36,14 +44,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "    class AlternativeModule(pytest.Module):\n",
-    "        def _getobj(self):\n",
-    "            return self.loader(self.parent.config.option.main and \"__main__\" or None).load(str(self.fspath))"
+    "    def pytest_addoption(parser):\n",
+    "        group = parser.getgroup(\"general\")\n",
+    "        group.addoption('--main', action='store_true', help=\"Run in the main context.\")        "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    class AlternativeModule(pytest.Module):\n",
+    "        def _getobj(self):\n",
+    "            return self.loader(\n",
+    "                self.parent.config.option.main and \"__main__\" or None\n",
+    "            ).load(str(self.fspath))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +74,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    import _pytest.doctest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,12 +95,16 @@
     "                        for pat in parent.config.getini('python_files'):\n",
     "                            if path.fnmatch(pat.rstrip('.py') + path.ext): break\n",
     "                        else: return\n",
-    "                    return module(path, parent)"
+    "                    if self.parent.config.option.doctestmodules:\n",
+    "                        classes = list(module.__mro__)\n",
+    "                        classes.insert(classes.index(_pytest.python.Module), _pytest.doctest.DoctestModule)\n",
+    "                        module = type('DocTest'+module.__name__, tuple(classes), {})\n",
+    "                    return module(path, parent)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 20,
    "metadata": {
     "scrolled": false
    },
@@ -90,8 +124,15 @@
    "source": [
     "    if __name__ ==  '__main__':\n",
     "        from importnb.utils.export import export\n",
-    "        export('pytest_plugin.ipynb', '../../utils/pytest_plugin.py')"
+    "        export('pytest_importnb.ipynb', '../../utils/pytest_importnb.py')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/src/importnb/notebooks/utils/pytest_nbsource.ipynb
+++ b/src/importnb/notebooks/utils/pytest_nbsource.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`pytest_nbsource` sets some rules when notebooks are used as source code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    with __import__('importnb').Notebook():\n",
+    "        try: from . import testing\n",
+    "        except: from importnb.utils import testing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    import importlib, pytest, abc, pathlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    from importnb import Notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    def pytest_addoption(parser):\n",
+    "        group = parser.getgroup(\"general\")\n",
+    "        group.addoption('--nbsource', action='store_true', help=\n",
+    "                        \"\"\"Notebook source code has monotonically increasing execution result\n",
+    "    values and a leading Markdown string is the docstring.\"\"\")\n",
+    "        "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    def pytest_collect_file(parent, path):\n",
+    "        \"\"\"`pytest_collect_file` will collect notebooks.\"\"\"\n",
+    "\n",
+    "        if path.ext == \".ipynb\": return NotebookFile(path, parent)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    " class NotebookFile(pytest.File):\n",
+    "    def collect(self):\n",
+    "        nb = __import__('json').load(self.fspath.open())\n",
+    "        if self.parent.config.option.nbsource:      \n",
+    "            yield AggregateNotebookTests(testing.assert_execution_order.__name__, \n",
+    "                    self, nb, testing.assert_execution_order)\n",
+    "            yield AggregateNotebookTests(\n",
+    "                testing.assert_markdown_docstring.__name__, \n",
+    "                self, nb, testing.assert_markdown_docstring)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "  class AggregateNotebookTests(pytest.Item):\n",
+    "        \"\"\"`AggregateNotebookTests` is a `pytest.Item` for testing features of notebook data.\"\"\"\n",
+    "\n",
+    "        def runtest(self):  return self.callable(self.nb)\n",
+    "        \n",
+    "        def __init__(self, name, parent, nb, callable):\n",
+    "            super().__init__(name, parent)\n",
+    "            self.nb, self.callable = nb, callable\n",
+    "        \n",
+    "        def reportinfo(self): \n",
+    "            \"\"\"`AggregateNotebookTests.repr_failure` is really similar the to the <b><i>render_traceback</i></b> attribute provided by `IPython` to customize tracebacks.\"\"\"\n",
+    "            return self.fspath, 0, \"usecase: %s\" % self.name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "    if __name__ ==  '__main__':\n",
+    "        from importnb.utils.export import export\n",
+    "        export('pytest_nbsource.ipynb', '../../utils/pytest_nbsource.py')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/importnb/notebooks/utils/testing.ipynb
+++ b/src/importnb/notebooks/utils/testing.ipynb
@@ -56,12 +56,10 @@
     "            id += shift\n",
     "            source = ''.join(object['source'])\n",
     "            if object['execution_count'] is None:\n",
-    "                if source.strip():\n",
-    "                    raise UnexecutedCell(F\"\"\"{file} has an unexecuted with the source:\\n{source}.\"\"\")\n",
+    "                assert not source.strip(), F\"\"\"{file} has an unexecuted with the source:\\n{source}.\"\"\"\n",
     "                shift -= 1\n",
     "            else:\n",
-    "                if object['execution_count'] != id:\n",
-    "                    raise OutOfOrder(F\"\"\"{file} has been executed out of order.\"\"\")\n",
+    "                assert object['execution_count'] == id, F\"\"\"{file} has been executed out of order.\"\"\"\n",
     "               \n",
     "        return True"
    ]
@@ -73,8 +71,7 @@
    "outputs": [],
    "source": [
     "    def assert_markdown_docstring(nb, name=None):\n",
-    "        if nb['cells'][0]['cell_type'] != 'markdown':\n",
-    "            raise MissingMarkdownDocstring(F\"\"\"{name} is a missing a Markdown doc cell.\"\"\")\n",
+    "        assert nb['cells'][0]['cell_type'] == 'markdown', F\"\"\"{name} should begin a Markdown cell that describes the purpose of the source.\"\"\"\n",
     "        return True"
    ]
   },

--- a/src/importnb/notebooks/utils/testing.ipynb
+++ b/src/importnb/notebooks/utils/testing.ipynb
@@ -56,10 +56,10 @@
     "            id += shift\n",
     "            source = ''.join(object['source'])\n",
     "            if object['execution_count'] is None:\n",
-    "                assert not source.strip(), F\"\"\"{file} has an unexecuted with the source:\\n{source}.\"\"\"\n",
+    "                assert not source.strip(), \"\"\"{file} has an unexecuted with the source:\\n{source}.\"\"\".format(**locals())\n",
     "                shift -= 1\n",
     "            else:\n",
-    "                assert object['execution_count'] == id, F\"\"\"{file} has been executed out of order.\"\"\"\n",
+    "                assert object['execution_count'] == id, \"\"\"{file} has been executed out of order.\"\"\".format(**locals())\n",
     "               \n",
     "        return True"
    ]
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "    def assert_markdown_docstring(nb, name=None):\n",
-    "        assert nb['cells'][0]['cell_type'] == 'markdown', F\"\"\"{name} should begin a Markdown cell that describes the purpose of the source.\"\"\"\n",
+    "        assert nb['cells'][0]['cell_type'] == 'markdown', \"\"\"{name} should begin a Markdown cell that describes the purpose of the source.\"\"\".format(**locals())\n",
     "        return True"
    ]
   },

--- a/src/importnb/notebooks/utils/testing.ipynb
+++ b/src/importnb/notebooks/utils/testing.ipynb
@@ -1,0 +1,136 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Utility functions to test the quality of a source notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    import json, pathlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    class UnexecutedCell(BaseException): ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    class OutOfOrder(BaseException): ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    class MissingMarkdownDocstring(BaseException): ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    def assert_execution_order(nb, file=None):\n",
+    "        shift = 1\n",
+    "        for id, object in enumerate(\n",
+    "            object for object in nb['cells'] if object['cell_type'] == 'code'):\n",
+    "            id += shift\n",
+    "            source = ''.join(object['source'])\n",
+    "            if object['execution_count'] is None:\n",
+    "                if source.strip():\n",
+    "                    raise UnexecutedCell(F\"\"\"{file} has an unexecuted with the source:\\n{source}.\"\"\")\n",
+    "                shift -= 1\n",
+    "            else:\n",
+    "                if object['execution_count'] != id:\n",
+    "                    raise OutOfOrder(F\"\"\"{file} has been executed out of order.\"\"\")\n",
+    "               \n",
+    "        return True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    def assert_markdown_docstring(nb, name=None):\n",
+    "        if nb['cells'][0]['cell_type'] != 'markdown':\n",
+    "            raise MissingMarkdownDocstring(F\"\"\"{name} is a missing a Markdown doc cell.\"\"\")\n",
+    "        return True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "    if __name__ ==  '__main__':\n",
+    "        from importnb.utils.export import export\n",
+    "        export('testing.ipynb', '../../utils/testing.py')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    def test_assert_monotonic_execution_order():\n",
+    "        __file__ = globals().get('__file__', 'testing.ipynb')\n",
+    "        nb = json.loads(pathlib.Path(__file__).read_text())\n",
+    "        assert assert_execution_order(nb, __file__)\n",
+    "        assert assert_markdown_docstring(nb, __file__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/importnb/utils/pytest_importnb.py
+++ b/src/importnb/utils/pytest_importnb.py
@@ -44,7 +44,7 @@ class AlternativeSourceText(abc.ABCMeta):
                             break
                     else:
                         return
-                if self.parent.config.option.doctestmodules:
+                if parent.config.option.doctestmodules:
                     classes = list(module.__mro__)
                     classes.insert(
                         classes.index(_pytest.python.Module), _pytest.doctest.DoctestModule

--- a/src/importnb/utils/pytest_nbsource.py
+++ b/src/importnb/utils/pytest_nbsource.py
@@ -1,0 +1,66 @@
+# coding: utf-8
+"""`pytest_nbsource` sets some rules when notebooks are used as source code.
+"""
+
+with __import__("importnb").Notebook():
+    try:
+        from . import testing
+    except:
+        from importnb.utils import testing
+
+import importlib, pytest, abc, pathlib
+
+from importnb import Notebook
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("general")
+    group.addoption(
+        "--nbsource",
+        action="store_true",
+        help="""Notebook source code has monotonically increasing execution result
+values and a leading Markdown string is the docstring.""",
+    )
+
+
+def pytest_collect_file(parent, path):
+    """`pytest_collect_file` will collect notebooks."""
+
+    if path.ext == ".ipynb":
+        return NotebookFile(path, parent)
+
+
+class NotebookFile(pytest.File):
+    def collect(self):
+        nb = __import__("json").load(self.fspath.open())
+        if self.parent.config.option.nbsource:
+            yield AggregateNotebookTests(
+                testing.assert_execution_order.__name__, self, nb, testing.assert_execution_order
+            )
+            yield AggregateNotebookTests(
+                testing.assert_markdown_docstring.__name__,
+                self,
+                nb,
+                testing.assert_markdown_docstring,
+            )
+
+
+class AggregateNotebookTests(pytest.Item):
+    """`AggregateNotebookTests` is a `pytest.Item` for testing features of notebook data."""
+
+    def runtest(self):
+        return self.callable(self.nb)
+
+    def __init__(self, name, parent, nb, callable):
+        super().__init__(name, parent)
+        self.nb, self.callable = nb, callable
+
+    def reportinfo(self):
+        """`AggregateNotebookTests.repr_failure` is really similar the to the <b><i>render_traceback</i></b> attribute provided by `IPython` to customize tracebacks."""
+        return self.fspath, 0, "usecase: %s" % self.name
+
+
+if __name__ == "__main__":
+    from importnb.utils.export import export
+
+    export("pytest_nbsource.ipynb", "../../utils/pytest_nbsource.py")

--- a/src/importnb/utils/testing.py
+++ b/src/importnb/utils/testing.py
@@ -1,0 +1,52 @@
+# coding: utf-8
+"""Utility functions to test the quality of a source notebook.
+"""
+
+import json, pathlib
+
+
+class UnexecutedCell(BaseException):
+    ...
+
+
+class OutOfOrder(BaseException):
+    ...
+
+
+class MissingMarkdownDocstring(BaseException):
+    ...
+
+
+def assert_execution_order(nb, file=None):
+    shift = 1
+    for id, object in enumerate(object for object in nb["cells"] if object["cell_type"] == "code"):
+        id += shift
+        source = "".join(object["source"])
+        if object["execution_count"] is None:
+            if source.strip():
+                raise UnexecutedCell(f"""{file} has an unexecuted with the source:\n{source}.""")
+            shift -= 1
+        else:
+            if object["execution_count"] != id:
+                raise OutOfOrder(f"""{file} has been executed out of order.""")
+
+    return True
+
+
+def assert_markdown_docstring(nb, name=None):
+    if nb["cells"][0]["cell_type"] != "markdown":
+        raise MissingMarkdownDocstring(f"""{name} is a missing a Markdown doc cell.""")
+    return True
+
+
+if __name__ == "__main__":
+    from importnb.utils.export import export
+
+    export("testing.ipynb", "../../utils/testing.py")
+
+
+def test_assert_monotonic_execution_order():
+    __file__ = globals().get("__file__", "testing.ipynb")
+    nb = json.loads(pathlib.Path(__file__).read_text())
+    assert assert_execution_order(nb, __file__)
+    assert assert_markdown_docstring(nb, __file__)

--- a/src/importnb/utils/testing.py
+++ b/src/importnb/utils/testing.py
@@ -23,19 +23,18 @@ def assert_execution_order(nb, file=None):
         id += shift
         source = "".join(object["source"])
         if object["execution_count"] is None:
-            if source.strip():
-                raise UnexecutedCell(f"""{file} has an unexecuted with the source:\n{source}.""")
+            assert not source.strip(), f"""{file} has an unexecuted with the source:\n{source}."""
             shift -= 1
         else:
-            if object["execution_count"] != id:
-                raise OutOfOrder(f"""{file} has been executed out of order.""")
+            assert object["execution_count"] == id, f"""{file} has been executed out of order."""
 
     return True
 
 
 def assert_markdown_docstring(nb, name=None):
-    if nb["cells"][0]["cell_type"] != "markdown":
-        raise MissingMarkdownDocstring(f"""{name} is a missing a Markdown doc cell.""")
+    assert (
+        nb["cells"][0]["cell_type"] == "markdown"
+    ), f"""{name} should begin a Markdown cell that describes the purpose of the source."""
     return True
 
 

--- a/src/importnb/utils/testing.py
+++ b/src/importnb/utils/testing.py
@@ -23,10 +23,16 @@ def assert_execution_order(nb, file=None):
         id += shift
         source = "".join(object["source"])
         if object["execution_count"] is None:
-            assert not source.strip(), f"""{file} has an unexecuted with the source:\n{source}."""
+            assert (
+                not source.strip()
+            ), """{file} has an unexecuted with the source:\n{source}.""".format(
+                **locals()
+            )
             shift -= 1
         else:
-            assert object["execution_count"] == id, f"""{file} has been executed out of order."""
+            assert (
+                object["execution_count"] == id
+            ), """{file} has been executed out of order.""".format(**locals())
 
     return True
 
@@ -34,7 +40,9 @@ def assert_execution_order(nb, file=None):
 def assert_markdown_docstring(nb, name=None):
     assert (
         nb["cells"][0]["cell_type"] == "markdown"
-    ), f"""{name} should begin a Markdown cell that describes the purpose of the source."""
+    ), """{name} should begin a Markdown cell that describes the purpose of the source.""".format(
+        **locals()
+    )
     return True
 
 


### PR DESCRIPTION
Adds new `--nbsource` checks to see if a note book is run all and has a docstring.  The pytest extensions are split across two files and renamed.