### PR TITLE
dont support formatted strings for doctests

### DIFF
--- a/src/importnb/docstrings.py
+++ b/src/importnb/docstrings.py
@@ -16,11 +16,6 @@ create_test = ast.parse("""__test__ = globals().get('__test__', {})""", mode="si
 test_update = ast.parse("""__test__.update""", mode="single").body[0].value
 str_nodes = (ast.Str,)
 
-try:
-    str_nodes += (ast.JoinedStr,)
-except:
-    ...
-
 """`TestStrings` is an `ast.NodeTransformer` that captures `str_nodes` in the `TestStrings.strings` object.
 
 ```ipython

--- a/src/importnb/notebooks/docstrings.ipynb
+++ b/src/importnb/notebooks/docstrings.ipynb
@@ -36,11 +36,7 @@
    "source": [
     "    create_test = ast.parse(\"\"\"__test__ = globals().get('__test__', {})\"\"\", mode='single').body[0]\n",
     "    test_update = ast.parse('''__test__.update''', mode='single').body[0].value    \n",
-    "    str_nodes = ast.Str, \n",
-    "    \n",
-    "    try:\n",
-    "        str_nodes += ast.JoinedStr,\n",
-    "    except: ..."
+    "    str_nodes = ast.Str, "
    ]
   },
   {


### PR DESCRIPTION
Only permit non-formatted strings as doctests.