### PR TITLE
Add requested loader features to include only definitions and comment magics.

### DIFF
--- a/src/importnb/loader.py
+++ b/src/importnb/loader.py
@@ -250,10 +250,10 @@ class DefsOnly(ast.NodeTransformer):
     INCLUDE = ast.Import, ast.ImportFrom, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef
 
     def visit_Module(self, node):
-        return ast.Module(
-            [x for x in node.body if isinstance(x, self.INCLUDE)],
-            node.type_ignores,
-        )
+        args = ([x for x in node.body if isinstance(x, self.INCLUDE)],)
+        if _GTE38:
+            args += (node.type_ignores,)
+        return ast.Module(*args)
 
 
 """## The `Notebook` finder & loader

--- a/tests/test_cli.ipynb
+++ b/tests/test_cli.ipynb
@@ -157,7 +157,7 @@
     }
    ],
    "source": [
-    "    #NBVAL_SKIP\n",
+    "    #NBVAL_IGNORE_OUTPUT\n",
     "    !importnb install"
    ]
   },
@@ -176,7 +176,7 @@
     }
    ],
    "source": [
-    "    #NBVAL_SKIP\n",
+    "    #NBVAL_IGNORE_OUTPUT\n",
     "    !importnb uninstall"
    ]
   }

--- a/tests/test_data/cherry_pick.ipynb
+++ b/tests/test_data/cherry_pick.ipynb
@@ -1,0 +1,70 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A notebook to test the defs_only and no_magic features in `importnb`. \n",
+    "this notebook is a good example because one can imagine it being developed using magics.\n",
+    "then the author only wanted to use their utility functions.\n",
+    "under normal circumstances the author would have to provide `get_ipython` from the magic to work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    an_expr = \"hello\"\n",
+    "    class AClass:\n",
+    "        an_expr = \"bye\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "no\n"
+     ]
+    }
+   ],
+   "source": [
+    "    %%python\n",
+    "    print(\"no\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.10 ('base')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "fe3da9b82b3647283ed4a64afb514c08b1aa39774194ba3fa7469a9333d7260c"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_importnb.ipynb
+++ b/tests/test_importnb.ipynb
@@ -56,6 +56,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    def unimport(ns):\n",
+    "        \"\"\"unimport a module namespace\"\"\"\n",
+    "        from sys import modules, path_importer_cache\n",
+    "\n",
+    "        for module in [x for x in modules if x.startswith(ns)]:\n",
+    "            del modules[module]\n",
+    "\n",
+    "        path_importer_cache.clear()"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
    "outputs": [],
@@ -93,7 +109,7 @@
    "source": [
     "    @fixture\n",
     "    def package():\n",
-    "        with Notebook(): \n",
+    "        with Notebook():\n",
     "            import foobaz.foobar\n",
     "        yield foobaz.foobar\n",
     "        del foobaz"
@@ -308,6 +324,46 @@
     "            import ascript\n",
     "            \n",
     "        assert ascript.msg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    @mark.parametrize(\"defs\", [True, False])\n",
+    "    def test_defs_only(defs):\n",
+    "        \"\"\"import ipy scripts, this won't really work without ipython.\"\"\"\n",
+    "        with Notebook(defs_only=defs):\n",
+    "            if defs:\n",
+    "                from test_data import cherry_pick\n",
+    "                attr = hasattr(cherry_pick, \"an_expr\")\n",
+    "                assert not attr if defs else attr\n",
+    "                assert hasattr(cherry_pick, \"AClass\")\n",
+    "            else:\n",
+    "                with raises(BaseException):\n",
+    "                    from test_data import cherry_pick\n",
+    "        unimport(\"test_data\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    @mark.parametrize(\"magic\", [True, False])\n",
+    "    def test_no_magic(capsys, magic):\n",
+    "        with Notebook(no_magic=not magic):\n",
+    "            if magic:\n",
+    "                with raises(BaseException):\n",
+    "                    from test_data import cherry_pick\n",
+    "            else:\n",
+    "                from test_data import cherry_pick\n",
+    "                stdout = capsys.readouterr()[0]\n",
+    "                assert stdout if magic else not stdout\n",
+    "        unimport(\"test_data\")"
    ]
   },
   {


### PR DESCRIPTION
This addresses #119 #115 #116 

this pull request adds two extra flags to `importnb` to:

* exclude cell magics when importing a document
* include of function and class definitions. _this falls down when there are unscoped variables._

```
with importnb.Notebook(defs_only=True, no_magic=True):
    pass # will import only definitions and comment out magics. these flags can be used separately.
```

closes #119 #115 #116 