### PR TITLE
edge case on the parser

### DIFF
--- a/docs/Untitled42.ipynb
+++ b/docs/Untitled42.ipynb
@@ -39,7 +39,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "i was printed from <code> and my name is __main__\n"
+      "i was printed from  and my name is __main__\n"
      ]
     }
    ],
@@ -205,6 +205,47 @@
     "        if \"pytest\" not in sys.modules:\n",
     "            main(sys.argv[1:])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/json": {
+       "cell_type": null,
+       "cells": null,
+       "source": {},
+       "text": null
+      },
+      "text/plain": [
+       "<IPython.core.display.JSON object>"
+      ]
+     },
+     "metadata": {
+      "application/json": {
+       "expanded": false,
+       "root": "root"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if get_ipython():\n",
+    "    from IPython.display import JSON\n",
+    "    data = dict.fromkeys(\"cell_type source text cells\".split())\n",
+    "    data[\"source\"] = {}\n",
+    "    display(JSON(data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ skip-install = true
 dependencies = ["black", "isort"]
 
 [tool.hatch.envs.format.scripts]
-run = """
+code = """
 isort .
 black .
 """

--- a/src/importnb/decoder.py
+++ b/src/importnb/decoder.py
@@ -10,7 +10,7 @@ def quote(object, *, quotes="'''"):
     return quotes + object + "\n" + quotes
 
 
-from ._json_parser import Lark_StandAlone, Transformer
+from ._json_parser import Lark_StandAlone, Transformer, Tree
 
 
 class Transformer(Transformer):
@@ -32,11 +32,13 @@ class Transformer(Transformer):
     def item(self, s):
         key = s[0][-1]
         if key == "cells":
-            return self.render(list(map(dict, s[-1])))
+            if not isinstance(s[-1], Tree):
+                return self.render(list(map(dict, s[-1])))
         elif key in {"source", "text"}:
             return key, s[-1]
         elif key == "cell_type":
-            return key, s[-1][-1]
+            if isinstance(s[-1], tuple):
+                return key, s[-1][-1]
 
     def array(self, s):
         if s:


### PR DESCRIPTION
the inline lark to notebook parser has specific directives for known notebook file keys. when those are encounters in structured outputs like `JSON` data the parser breaks. these changes fix the parsing edge case and adds tests for verification.