### PR TITLE
introduce an entry points interface for loading modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ if you're here, then there is a chance you have a notebook (`.ipynb`) in a direc
 ## basic example 
 use `importnb`'s  `Notebook` finder and loader to import notebooks as modules
 
-    # with the new pai
+    # with the new api
     from importnb import imports
     with imports("ipynb"):
         import Untitled

--- a/README.md
+++ b/README.md
@@ -6,9 +6,18 @@ if you're here, then there is a chance you have a notebook (`.ipynb`) in a direc
 ## basic example 
 use `importnb`'s  `Notebook` finder and loader to import notebooks as modules
 
-    from importnb import Notebook
+    # with the new pai
+    from importnb import imports
+    with imports("ipynb"):
+        import Untitled
+
+    # with the explicit api
+    from importnb import imports
     with Notebook():
         import Untitled
+
+
+
 
 ### What does this snippet do?
 
@@ -44,7 +53,7 @@ use either `pip` or `conda/mamba`
   * fuzzy finding conventions for finding files that are not valid python names
 * works with top-level await statements
 * integration with `pytest`
-* extensible machinery
+* extensible machinery and entry points
 * translates Jupyter notebook files (ie `.ipynb` files) line-for-line to python source providing natural error messages
 * command line interface for running notebooks as python scripts
 * has no required dependencies
@@ -67,16 +76,28 @@ these features are defined in the `importnb.loader.Interface` class and they can
 
 the primary goal of this library is to make it easy to reuse python code in notebooks. below are a few ways to invoke python's import system within the context manager.
 
-    with importnb.Notebook():
-        import Untitled100
-        import Untitled100 as nb
-        __import__("Untitled100")
+    with importnb.imports("ipynb"):
+        import Untitled
+        import Untitled as nb
+        __import__("Untitled")
         from importlib import import_module
-        import_module("Untitled100")
+        import_module("Untitled")
+
+#### import data files
+
+there is support for discovering data files. when discovered, data from disk on loaded and stored on the module with rich reprs.
+
+    with importnb.imports("toml", "json", "yaml"):
+        pass
+
+all the available entry points are found with
+
+    from importnb.entry_points import list_aliases
+    list_aliases()
 
 #### loading directly from file 
 
-    Untitled100 = Notebook.load("Untitled100.ipynb")
+    Untitled = Notebook.load("Untitled.ipynb")
 
 
 ### fuzzy finding
@@ -84,14 +105,14 @@ the primary goal of this library is to make it easy to reuse python code in note
 often notebooks have names that are not valid python files names that are restricted alphanumeric characters and an `_`.  the `importnb` fuzzy finder converts python's import convention into globs that will find modules matching specific patters. consider the statement:
 
     with importnb.Notebook():
-        import U_titl__100                        # U*titl**100.ipynb
+        import U_titl__d                        # U*titl**d.ipynb
 
-`importnb` translates `U_titl__100` to a glob format that matches the pattern `U*titl**.ipynb` when searching for the source. that means that `importnb` should fine `Untitled100.ipynb` as the source for the import[^unless].
+`importnb` translates `U_titl__d` to a glob format that matches the pattern `U*titl**d.ipynb` when searching for the source. that means that `importnb` should fine `Untitled.ipynb` as the source for the import[^unless].
 
     with importnb.Notebook():
-        import _ntitled100                        # *ntitled100.ipynb
-        import __100                        # **100.ipynb
-        import U__100                        # U**100.ipynb
+        import _ntitled                        # *ntitled.ipynb
+        import __d                     # **d.ipynb
+        import U__                        # U**.ipynb
 
 a primary motivation for this feature is name notebooks as if they were blog posts using the `YYYY-MM-DD-title-here.ipynb` convention. there are a few ways we could this file explicitly. the fuzzy finder syntax could like any of the following:
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ("pytester",)

--- a/docs/test_importnb.py
+++ b/docs/test_importnb.py
@@ -295,7 +295,7 @@ def test_top_level_async():
 def test_data_loaders(pytester):
     some_random_data = {"top": [{}]}
 
-    import json, yaml, tomli_w, io
+    import json, ruamel.yaml as yaml, tomli_w, io
 
     sys.path.insert(0, str(pytester._path))
     pytester.makefile(".json", json_data=json.dumps(some_random_data))

--- a/docs/test_importnb.py
+++ b/docs/test_importnb.py
@@ -292,7 +292,6 @@ def test_top_level_async():
         import async_cells
 
 
-@mark.skipif(sys.implementation == "pypy", reason="pypy doesn't like this design choice")
 def test_data_loaders(pytester):
     some_random_data = {"top": [{}]}
 

--- a/docs/test_importnb.py
+++ b/docs/test_importnb.py
@@ -292,6 +292,7 @@ def test_top_level_async():
         import async_cells
 
 
+@mark.skipif(sys.implementation == "pypy", reason="pypy doesn't like this design choice")
 def test_data_loaders(pytester):
     some_random_data = {"top": [{}]}
 

--- a/docs/test_importnb.py
+++ b/docs/test_importnb.py
@@ -12,7 +12,7 @@ from types import FunctionType
 from pytest import fixture, mark, raises, skip
 
 import importnb
-from importnb import Notebook, get_ipython
+from importnb import Notebook, get_ipython, imports
 from importnb.loader import VERSION
 
 CLOBBER = ("Untitled42", "my_package", "__42", "__ed42", "__d42")
@@ -290,3 +290,22 @@ def test_cli(clean):
 def test_top_level_async():
     with Notebook():
         import async_cells
+
+
+def test_data_loaders(pytester):
+    some_random_data = {"top": [{}]}
+
+    import json, yaml, tomli_w, io
+
+    sys.path.insert(0, str(pytester._path))
+    pytester.makefile(".json", json_data=json.dumps(some_random_data))
+    pytester.makefile(".toml", toml_data=tomli_w.dumps(some_random_data))
+    y = io.StringIO()
+    yaml.safe_dump(some_random_data, y)
+    pytester.makefile(".yaml", yaml_data=y.getvalue())
+
+    with imports("json", "yaml", "toml"):
+        import json_data, yaml_data, toml_data
+    assert json_data.__file__.endswith(".json")
+    assert toml_data.__file__.endswith(".toml")
+    assert yaml_data.__file__.endswith(".yaml")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
   "License :: OSI Approved :: BSD License",
 ]
-dependencies = [] # no dependencies!
+dependencies = [
+  "importlib-metadata; python_version<'3.8'"
+] # no dependencies?
 dynamic = ["version"] # uses hatch-vcs
 
 [project.optional-dependencies]
@@ -57,7 +59,6 @@ build-backend = "hatchling.build"
 
 # hatch/hatchling configuration
 [tool.hatch.build.hooks.custom]
-
 # we build a json grammar with each release because we fiend for line numbers
 dependencies = ["lark"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ version-file = "src/importnb/_version.py"
 
 # test matrix
 [tool.hatch.envs.test]
-dependencies = ["pytest", "pytest-cov", "doit", "toml", "pyyaml", "tomli_w"]
+dependencies = ["pytest", "pytest-cov", "doit", "toml", "ruamel.yaml", "tomli_w"]
 
 [[tool.hatch.envs.test.matrix]]
 version = ["stdlib", "interactive"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,13 +70,13 @@ version-file = "src/importnb/_version.py"
 
 # test matrix
 [tool.hatch.envs.test]
-dependencies = ["pytest", "pytest-cov", "doit", "toml"]
+dependencies = ["pytest", "pytest-cov", "doit", "toml", "pyyaml", "tomli_w"]
 
 [[tool.hatch.envs.test.matrix]]
 version = ["stdlib", "interactive"]
 
 [tool.hatch.envs.test.overrides]
-matrix.version.features = [{value="interactive", if=["interactive"]}]
+matrix.version.features = [{ value = "interactive", if = ["interactive"] }]
 matrix.version.dev-mode = [{ value = false, env = ["CI=true"] }]
 
 [tool.hatch.envs.test.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,15 @@ tasks = ["doit", "toml"]
 [project.entry-points.pytest11]
 importnb = "importnb.utils.pytest_importnb"
 
+[project.entry-points.importnb]
+ipynb = "importnb.loader:Notebook"
+ipy = "importnb.loader:Notebook"
+py = "importnb.loader:Loader"
+json = "importnb.loaders:Json"
+yml = "importnb.loaders:Yaml"
+yaml = "importnb.loaders:Yaml"
+toml = "importnb.loaders:Toml"
+
 [project.scripts]
 importnb = "importnb.__main__:main"
 

--- a/src/importnb/__init__.py
+++ b/src/importnb/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-__all__ = "Notebook", "reload"
+__all__ = "Notebook", "reload", "imports"
 
 
 def is_ipython():
@@ -28,5 +28,6 @@ import builtins
 
 from ._version import __version__
 from .loader import Notebook, reload
+from .entry_points import imports
 
 builtins.true, builtins.false, builtins.null = True, False, None

--- a/src/importnb/entry_points.py
+++ b/src/importnb/entry_points.py
@@ -2,7 +2,18 @@ from .loader import Loader
 from dataclasses import dataclass, field
 from types import MethodType
 from contextlib import contextmanager, ExitStack
-from importlib.metadata import entry_points
+
+
+def _get_importnb_entry_points():
+    try:
+        from importlib.metadata import entry_points
+
+        yield from entry_points()["importnb"]
+    except ModuleNotFoundError:
+        from importlib_metadata import entry_points
+
+        yield from entry_points(group="importnb")
+
 
 __all__ = ("imports",)
 ENTRY_POINTS = dict()
@@ -11,7 +22,7 @@ ENTRY_POINTS = dict()
 def get_importnb_entry_points():
     """discover the known importnb entry points"""
     global ENTRY_POINTS
-    for ep in entry_points()["importnb"]:
+    for ep in _get_importnb_entry_points():
         ENTRY_POINTS[ep.name] = ep.value
     return ENTRY_POINTS
 

--- a/src/importnb/entry_points.py
+++ b/src/importnb/entry_points.py
@@ -1,0 +1,60 @@
+from .loader import Loader
+from dataclasses import dataclass, field
+from types import MethodType
+from contextlib import contextmanager, ExitStack
+from importlib.metadata import entry_points
+
+__all__ = ("imports",)
+ENTRY_POINTS = dict()
+
+
+def get_importnb_entry_points():
+    """discover the known importnb entry points"""
+    global ENTRY_POINTS
+    for ep in entry_points()["importnb"]:
+        ENTRY_POINTS[ep.name] = ep.value
+    return ENTRY_POINTS
+
+
+def loader_from_alias(alias):
+    """load an attribute from a module using the entry points value specificaiton"""
+    from importlib import import_module
+    from operator import attrgetter
+
+    module, _, member = alias.rpartition(":")
+    module = import_module(module)
+    return attrgetter(member)(module)
+
+
+def loader_from_ep(alias):
+    """discover a loader for an importnb alias or vaue"""
+    if ":" in alias:
+        return loader_from_alias(alias)
+
+    if not ENTRY_POINTS:
+        get_importnb_entry_points()
+
+    if alias in ENTRY_POINTS:
+        return loader_from_alias(ENTRY_POINTS[alias])
+
+    raise ValueError(f"{alias} is not a valid loader alias.")
+
+
+@contextmanager
+def imports(*names):
+    """a shortcut to importnb loaders through entrypoints"""
+    types = set()
+    with ExitStack() as stack:
+        for name in names:
+            t = loader_from_ep(name)
+            if t not in types:
+                stack.enter_context(t())
+                types.add(t)
+        yield stack
+
+
+def list_aliases():
+    """list the entry points associated with importnb"""
+    if not ENTRY_POINTS:
+        get_importnb_entry_points()
+    return list(ENTRY_POINTS)

--- a/src/importnb/loaders.py
+++ b/src/importnb/loaders.py
@@ -1,0 +1,60 @@
+from .loader import Loader
+from dataclasses import dataclass, field
+from types import MethodType
+
+
+class DataStreamLoader(Loader):
+    """an import loader for data streams"""
+
+    def exec_module(self, module):
+        with open(module.__file__, "rb") as file:
+            module.data = self.get_data_loader()(file)
+        module._repr_json_ = MethodType(repr_json, module)
+        return module
+
+    def get_data_loader(self):
+        raise NotImplementedError("load_data not implemented.")
+
+
+@dataclass
+class Json(DataStreamLoader):
+    """an import loader for json files"""
+
+    extensions: tuple = field(default_factory=[".json"].copy)
+
+    def get_data_loader(self):
+        from json import load
+
+        return load
+
+
+@dataclass
+class Yaml(DataStreamLoader):
+    """an import loader for yml and yaml"""
+
+    extensions: tuple = field(default_factory=[".yml", ".yaml"].copy)
+
+    def get_data_loader(self):
+        try:
+            from ruamel.yaml import safe_load
+        except ModuleNotFoundError:
+            from yaml import safe_load
+        # probably want an error message about how to fix this if we cant find yamls
+        return safe_load
+
+
+@dataclass
+class Toml(DataStreamLoader):
+    """an import loader for toml"""
+
+    extensions: tuple = field(default_factory=[".toml"].copy)
+
+    def get_data_loader(self):
+        try:
+            from tomllib import load
+        except ModuleNotFoundError:
+            from tomli import load
+        return load
+
+def repr_json(self):
+    return self.data, dict(root=repr(self), expanded=False)


### PR DESCRIPTION
to me, this is a significant change to `importnb` because it feels like the new api surface for importing alternative documents. the new interface looks like:

    with imports("ipynb", "json", "yaml", "toml"):
         import Untitled, package, mkdocs, pyproject

the context manager resolves the `[project.entry-points.importnb]` definitions and appends the loader associated with them to the `sys.path_hooks`. within the context, any of the aliased loaders are free game for python to import.

this approach allows other packages to make their loaders available to a single API. `midgy`, a package for using markdown files as python scripts, defines the `md` entry point. so with `midgy` installed:

    with imports("md"):
         import README

- [x] new `entry_points` source
- [x] docstrings and tests
- [ ] command line support - import a file and get a pretty repr
- [ ] pass arguments to `imports`
- [x] documentation

## code is not special

we're in the midst of adopting computational literacy as mass literacy. code is everywhere and people are eager to learn it. they are finding coding embedded in common file formats like markdown, docx, pptx, pdf, zip, ... it is in every nook and cranny of daily life. being restrictive about what is code will exhaust the enforcer.

`importnb` started as a way to avoid copy/pasting code from jupyter notebooks to python to test it efficacy;
the redundancy in work seemed counterintuitive. as a tool, `importnb` allow us to hide a lot of complex logic that might hinder the literary quality of a notebook. it allowed us to use notebooks to talk about notebooks, and, as always, we had fun doing it.

ultimately, `importnb` became a powerful tool for tuning the literary qualities of notebooks for docs, demos, and blogs.
it allowed us to tell more complex stories by encapsulating logic in different notebook documents.
ultimately, `importnb` and these inclusive importing features exist for the sake of the story; they exist as literary devices. 

the concept of importing non-python documents seems consistent with the message in computer programming for everybody. i feel like part of that mission requires a more inclusive perspective on what is code. one way to express this belief is to permit imports of othered code.

## problems

* disambiguation - what happens when there are two `md` or `csv` or `parquet` loaders
* you have environment problems when you need an extension