### PR TITLE
stricter lark grammar for notebook documents

### DIFF
--- a/src/json.g
+++ b/src/json.g
@@ -2,7 +2,8 @@
 // this grammar extracts a subset of nbformat (cells, cell_type, source)
 // to generate a line for line reconstruction of the source.
 
-?start: value
+?start: nb
+
 ?value: object
         | array
         | string
@@ -12,18 +13,38 @@
         | "null"             
 
 
-COLON: ":"
+_QUOTE: /"/
+_COLON: ":"
 array  : "[" [value ("," value)*] "]"
-object : "{" [_items] "}"
+object : "{" items* "}"
+item: string _COLON value
+items: item ("," item)*
+string: STRING
 
-item: string COLON value
-        
-_items: item ("," item)*
+_key{key}: _QUOTE key _QUOTE
+_pair{key, target}: _key{key} _COLON target
 
-string : ESCAPED_STRING
+// notebook parts
+?nb: "{" (_top ("," _top)*)+ "}"
+_top: cells | metadata | nbformat | nbformat_minor
+_cells: "[" cell ("," cell)* "]"
+cells: _pair{ "cells", _cells }
+metadata: _pair{"metadata", object}
+nbformat: _pair{"nbformat", SIGNED_NUMBER}
+nbformat_minor: _pair{"nbformat_minor", SIGNED_NUMBER}
+cell: "{" _cell_pairs ("," _cell_pairs)* "}"
+
+// cell parts
+_cell_pairs: source | outputs | attachments | cell_type | execution_count | metadata 
+_source: "[" (string ("," string)*)? "]" | string
+source: _pair{"source", _source}
+outputs: _pair{"outputs", array}
+attachments: _pair{"attachments", object}
+cell_type: _pair{"cell_type", string}
+execution_count: _pair{"execution_count", value }
         
-%import common.ESCAPED_STRING
+%import common.ESCAPED_STRING -> STRING
 %import common.SIGNED_NUMBER
-%import common.WS
- 
+%import co`mmon.WS
+
 %ignore WS

--- a/src/json.g
+++ b/src/json.g
@@ -1,50 +1,53 @@
 // a lark grammar for parsing notebooks into source
 // this grammar extracts a subset of nbformat (cells, cell_type, source)
 // to generate a line for line reconstruction of the source.
+             
 
+// rules for the top level notebook.
+// notebook files are json encoded and back with a json schema.
+// the schema allows us to create a more specific grammar
+// that is a aware of the schema supporting validation sooner in the parsing stage.
 ?start: nb
-
-?value: object
-        | array
-        | string
-        | SIGNED_NUMBER      
-        | "true"             
-        | "false"            
-        | "null"             
-
-
-_QUOTE: /"/
-_COLON: ":"
-array  : "[" [value ("," value)*] "]"
-object : "{" items* "}"
-item: string _COLON value
-items: item ("," item)*
-string: STRING
-
-_key{key}: _QUOTE key _QUOTE
-_pair{key, target}: _key{key} _COLON target
-
-// notebook parts
-?nb: "{" (_top ("," _top)*)+ "}"
-_top: cells | metadata | nbformat | nbformat_minor
+?nb: "{" (_nb ("," _nb)*)+ "}"
+_nb: cells | metadata | nbformat | nbformat_minor
 _cells: "[" cell ("," cell)* "]"
 cells: _pair{ "cells", _cells }
 metadata: _pair{"metadata", object}
 nbformat: _pair{"nbformat", SIGNED_NUMBER}
 nbformat_minor: _pair{"nbformat_minor", SIGNED_NUMBER}
-cell: "{" _cell_pairs ("," _cell_pairs)* "}"
+cell: "{" _cell ("," _cell)* "}"
 
-// cell parts
-_cell_pairs: source | outputs | attachments | cell_type | execution_count | metadata 
+// rules for the notebook cells
+_cell: source | outputs | attachments | cell_type | execution_count | metadata 
 _source: "[" (string ("," string)*)? "]" | string
 source: _pair{"source", _source}
 outputs: _pair{"outputs", array}
 attachments: _pair{"attachments", object}
 cell_type: _pair{"cell_type", string}
-execution_count: _pair{"execution_count", value }
+_execution_count: "null" | SIGNED_NUMBER
+execution_count: _pair{"execution_count", _execution_count}
+
+// terminals and rules for parsing generic json.
+_QUOTE: /"/
+_COLON: ":"
+array  : "[" [_any ("," _any)*] "]"
+object : "{" items* "}"
+item: string _COLON _any
+items: item ("," item)*
+string: STRING
+_any: object
+        | array
+        | string
+        | SIGNED_NUMBER      
+        | "true"             
+        | "false"            
+        | "null"
+
+_key{key}: _QUOTE key _QUOTE
+_pair{key, target}: _key{key} _COLON target
+
         
 %import common.ESCAPED_STRING -> STRING
 %import common.SIGNED_NUMBER
-%import co`mmon.WS
-
+%import common.WS
 %ignore WS


### PR DESCRIPTION
this pull request modifies the json parser to use explicit properties from the notebook format to constrain the parser.

the top-level notebook keys and cell keys are known ahead of time because of the schema that notebooks conform to. these changes hard code the notebook and cell properties into the parser. 

this change will NOT work for arbitrary data formats, only those conforming to subsets of the specified schema. otherwise the parser throws errors.

this change streamlines the transformation logic.