### PR TITLE
fix pypi test release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
   "License :: OSI Approved :: BSD License",
 ]
-dependencies = [
-  "importlib-metadata >=4.8.3;python_version<\"3.10\"",
-]
+dependencies = ["importlib-metadata >=4.8.3;python_version<\"3.10\""]
 dynamic = ["version"] # uses hatch-vcs
 
 [project.optional-dependencies]
@@ -71,7 +69,14 @@ version-file = "src/importnb/_version.py"
 
 # test matrix
 [tool.hatch.envs.test]
-dependencies = ["pytest", "pytest-cov", "doit", "tomli", "ruamel.yaml", "tomli_w"]
+dependencies = [
+  "pytest",
+  "pytest-cov",
+  "doit",
+  "tomli",
+  "ruamel.yaml",
+  "tomli_w",
+]
 
 [[tool.hatch.envs.test.matrix]]
 version = ["stdlib", "interactive"]
@@ -104,8 +109,16 @@ show_contexts = true
 
 # test a release on test-pypi
 [tool.hatch.envs.released]
-skip-install = true
-dependencies = ["importnb", "IPython", "pytest", "pytest-cov", "doit"]
+# skip-install = true
+dependencies = [
+  "importnb",
+  "IPython",
+  "pytest",
+  "pytest-cov",
+  "doit",
+  "tomli_w",
+  "ruamel.yaml",
+]
 
 [tool.hatch.envs.released.scripts]
 test = "pytest"


### PR DESCRIPTION
we've got a check that verifies the release on the test pypi. it is [failing](https://github.com/deathbeds/importnb/actions/runs/6727859354). this pull request fixes the dependencies needed for testing.