### PR TITLE
Don't run pytest under coverage on pypy, cache hatch envs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,5 +57,9 @@ jobs:
           cache-dependency-path: pyproject.toml
       - name: install dev dependencies
         run: python -m pip install --upgrade pip hatch
-      - name: run tests
+      - name: run tests (coverage)
+        if: ${{ !contains(matrix.python-version, 'pypy') }}
         run: hatch run test:cov
+      - name: run tests (no coverage)
+        if: ${{ contains(matrix.python-version, 'pypy') }}
+        run: hatch run test:run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CACHE_EPOCH: 0
+
 jobs:
   format:
     name: format
@@ -45,9 +48,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9"]
+        include:
+          - os: ubuntu-latest
+            hatch-envs: /home/runner/.local/share/hatch/env
+          - os: macos-latest
+            hatch-envs: /Users/runner/Library/Application Support/hatch/env
+          - os: windows-latest
+            hatch-envs: C:\Users\runneradmin\AppData\Local\hatch\env
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4
@@ -55,6 +65,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: pyproject.toml
+      - name: cache hatch envs
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ matrix.hatch-envs }}
+          key: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
       - name: install dev dependencies
         run: python -m pip install --upgrade pip hatch
       - name: run tests (coverage)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,10 @@ matrix.version.features = [{ value = "interactive", if = ["interactive"] }]
 matrix.version.dev-mode = [{ value = false, env = ["CI=true"] }]
 
 [tool.hatch.envs.test.scripts]
-cov = "pytest"
+cov = """
+pytest --cov=importnb --cov-branch --cov-context=test --cov-report=html --cov-report=term-missing:skip-covered --no-cov-on-fail
+"""
+run = "pytest"
 
 [tool.hatch.envs.released]
 # test a release on test-pypi
@@ -218,12 +221,6 @@ addopts = [
   "-vv",
   "--tb=long",
   "--color=yes",
-  "--cov=importnb",
-  "--cov-branch",
-  "--cov-context=test",
-  "--cov-report=html",
-  "--cov-report=term-missing:skip-covered",
-  "--no-cov-on-fail",
   "-ppytester",
 ]
 filterwarnings = [


### PR DESCRIPTION
## References

- starts #154

## Changes

- [x] don't run pytest with coverage under pypy
- [x] cache hatch envs

## Data
| data point | time |
|-|-|
| last run of `main` | 7m 1s |
| without `cov` on pypy | 3m 53s | 
| + cold cache with hatch envs | 4m 18s |
| + warm cache | 2m 9s |